### PR TITLE
Add domain mapping endpoints

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -91,6 +91,32 @@ Managing your account and billing:
         print("  ---")
 
 
+Domain Mapping
+--------------
+
+Find the service for a website before starting a verification, then retrieve
+all normalized domains mapped to that service:
+
+.. code-block:: python
+
+    from textverified import TextVerified
+
+    client = TextVerified(api_key="your_api_key", api_username="your_username")
+
+    # A hostname also works; full HTTP(S) URLs are normalized by the API.
+    services = client.services.services_for_domain("https://accounts.example.com/login")
+
+    if not services:
+        print("No matching TextVerified service was found.")
+    else:
+        service = services[0]
+        print(f"Matched {service.service_name}: {service.description}")
+
+        # The reverse lookup returns normalized registrable domains.
+        for domain in client.services.domains_for_service(service.service_name):
+            print(f"  {domain}")
+
+
 Bulk Rental Processing / Management
 ---------------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -106,6 +106,41 @@ increases frequently.
    for service in all_services:
       print(f"Service: {service.service_name}")
 
+Domain-to-Service and Service-to-Domain Mapping
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the domain mapping methods when you have a website hostname or URL and
+need the matching TextVerified service, or when you need the normalized domains
+associated with a service. These endpoints accept authenticated client requests
+but are maintained outside the Swagger schema.
+
+``services_for_domain`` accepts a hostname or a complete HTTP(S) URL. The API
+normalizes the input to its registrable domain, so a URL such as
+``https://login.example.com/sign-in`` can match ``example.com``. It returns
+regular ``Service`` objects; the target's display name is available as
+``service.description``.
+
+``domains_for_service`` accepts a TextVerified service name and returns its
+normalized domains.
+
+.. code-block:: python
+
+   from textverified import TextVerified
+
+   client = TextVerified(api_key="your_api_key", api_username="your_username")
+
+   # Domain or URL -> matching services
+   matching_services = client.services.services_for_domain(
+       "https://login.example.com/sign-in"
+   )
+   for service in matching_services:
+       print(f"{service.service_name}: {service.description} ({service.capability.value})")
+
+   # Service name -> normalized domains
+   domains = client.services.domains_for_service("example-service")
+   for domain in domains:
+       print(domain)
+
 Creating a Verification
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/mock_endpoints/api.v2.services.by-domain.json
+++ b/tests/mock_endpoints/api.v2.services.by-domain.json
@@ -1,0 +1,14 @@
+{
+  "get": {
+    "query_params": {
+      "domain": "https://login.example.com/path"
+    },
+    "response": [
+      {
+        "serviceName": "example-service",
+        "customerDisplayServiceName": "Example Service",
+        "capability": "sms"
+      }
+    ]
+  }
+}

--- a/tests/mock_endpoints/api.v2.services.{serviceName}.domains.json
+++ b/tests/mock_endpoints/api.v2.services.{serviceName}.domains.json
@@ -1,0 +1,11 @@
+{
+  "get": {
+    "path_params": {
+      "serviceName": "example-service"
+    },
+    "response": [
+      "example.com",
+      "example.net"
+    ]
+  }
+}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -63,3 +63,18 @@ def test_get_verification_inventory(tv, mock_http_from_disk):
 
     assert isinstance(inventory, InventoryQuantity)
     assert inventory.available_quantity == 37
+
+
+def test_get_services_for_domain(tv, mock_http_from_disk):
+    services = tv.services.services_for_domain("https://login.example.com/path")
+
+    assert [service.service_name for service in services] == ["example-service"]
+    assert services[0].description == "Example Service"
+    assert services[0].capability == ReservationCapability.SMS
+    assert mock_http_from_disk.call_args[1]["params"] == {"domain": "https://login.example.com/path"}
+
+
+def test_get_domains_for_service(tv, mock_http_from_disk):
+    domains = tv.services.domains_for_service("example-service")
+
+    assert domains == ["example.com", "example.net"]

--- a/textverified/services_api.py
+++ b/textverified/services_api.py
@@ -1,5 +1,6 @@
 from .action import _ActionPerformer, _Action
 from typing import List
+from urllib.parse import quote
 from .data import (
     AreaCode,
     InventoryQuantity,
@@ -116,3 +117,51 @@ class ServicesAPI:
             _Action(method="POST", href="/api/pub/v2/inventory/verifications"), json=data.to_api()
         )
         return InventoryQuantity.from_api(response.data)
+
+    def services_for_domain(self, domain: str) -> List[Service]:
+        """Return services mapped to a hostname or HTTP(S) URL.
+
+        The endpoint normalizes a hostname or full URL to its registrable domain.
+        The returned service objects use the target's display name as their
+        ``description``.
+
+        Args:
+            domain: A hostname or complete HTTP(S) URL to look up.
+
+        Returns:
+            Matching services. An empty list indicates that no service is mapped
+            to the supplied domain.
+        """
+        if not isinstance(domain, str) or not domain.strip():
+            raise ValueError("domain must be a non-empty hostname or HTTP(S) URL.")
+
+        response = self.client._perform_action(
+            _Action(method="GET", href="/api/v2/services/by-domain"), params={"domain": domain.strip()}
+        )
+        return [
+            Service.from_api(
+                {
+                    "serviceName": target["serviceName"],
+                    "capability": target["capability"],
+                    "description": target.get("customerDisplayServiceName"),
+                }
+            )
+            for target in response.data
+        ]
+
+    def domains_for_service(self, service_name: str) -> List[str]:
+        """Return normalized domains mapped to a service name.
+
+        Args:
+            service_name: The TextVerified service name to look up.
+
+        Returns:
+            Normalized domains associated with the service, or an empty list
+            when no mappings exist.
+        """
+        if not isinstance(service_name, str) or not service_name.strip():
+            raise ValueError("service_name must be a non-empty service name.")
+
+        action = _Action(method="GET", href=f"/api/v2/services/{quote(service_name.strip(), safe='')}/domains")
+        response = self.client._perform_action(action)
+        return [str(domain) for domain in response.data]


### PR DESCRIPTION
## Summary
- Add service-to-domain and domain-to-service mapping endpoints outside Swagger
- Add Sphinx documentation and usage examples

## Validation
- conda run -n tv-py37 python -m pytest