### PR TITLE
Add server-backed API mocking

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Python wrapper for the TextVerified API.
    :caption: Contents:
 
    quickstart
+   mocking
    api_reference
    examples
 

--- a/docs/mocking.rst
+++ b/docs/mocking.rst
@@ -6,8 +6,9 @@ deduct balance or create real resources. The client exposes those scenarios as
 ``TestMode`` enum values and sends their documented service name only for the
 operations that accept ``service_name``.
 
-Test modes are disabled by default: ``textverified.test_mode`` is ``None``.
-There is deliberately no "off" enum; use ``None`` to disable testing.
+The base mode is ``LIVE``: ``textverified.test_mode`` is
+``TestMode.LIVE`` by default. ``test=None`` inherits the client or global
+mode; use ``LIVE`` explicitly to force ordinary API behavior.
 
 Configuration Scopes
 --------------------
@@ -48,8 +49,9 @@ Every service-name operation accepts a per-call ``test`` override:
    )
 
 The order of precedence is per-call ``test``, per-client ``test_mode``, then
-global ``textverified.test_mode``. Omitting ``test`` inherits that setting;
-passing ``test=None`` explicitly disables testing for that call.
+global ``textverified.test_mode``. ``test=None`` (including the default)
+inherits that setting. Use ``test=LIVE`` to make one call live even when a
+parent scope selects a test scenario.
 
 Supported Operations
 --------------------
@@ -73,6 +75,7 @@ The enum values below correspond directly to Phoneblur's documented server
 scenarios. They are also available as module-level names, such as
 ``textverified.MOCK_SUCCESS``.
 
+* ``LIVE`` — normal API behavior; this is the default.
 * ``MOCK_SUCCESS`` — successful verification or active rental.
 * ``MOCK_DELAYED_SUCCESS`` and ``MOCK_PENDING`` — verification polling flows.
 * ``MOCK_TIMEOUT`` and ``MOCK_REACTIVATABLE`` — verification terminal states.

--- a/docs/mocking.rst
+++ b/docs/mocking.rst
@@ -1,105 +1,112 @@
-API Mocking
-===========
+Server Test Modes
+=================
 
-The client can use Phoneblur's server-backed mock scenarios for integration and
-development testing. Mock responses are deterministic, never deduct balance,
-and never create real resources.
+The Phoneblur API provides server-backed ``test_*`` scenarios. They never
+deduct balance or create real resources. The client exposes those scenarios as
+``TestMode`` enum values and sends their documented service name only for the
+operations that accept ``service_name``.
 
-Enable Mocking
---------------
+Test modes are disabled by default: ``textverified.test_mode`` is ``None``.
+There is deliberately no "off" enum; use ``None`` to disable testing.
 
-Mocking is disabled by default. Enable it with the package-level flag or its
-helper function before making requests:
+Configuration Scopes
+--------------------
+
+Set a global mode for clients that inherit the package setting:
 
 .. code-block:: python
 
    import textverified
-   from textverified import TextVerified, NumberType, ReservationCapability
+   from textverified import MOCK_SUCCESS
 
-   textverified.mock_api = True
-   # Equivalent: textverified.set_mock_api(True)
+   textverified.test_mode = MOCK_SUCCESS
+   # Equivalent: textverified.set_test_mode(MOCK_SUCCESS)
 
-   client = TextVerified(api_key="your_api_key", api_username="your_username")
-   verification = client.verifications.create(
+Set a mode for one client:
+
+.. code-block:: python
+
+   from textverified import TextVerified, MOCK_PENDING
+
+   client = TextVerified(
+       api_key="your_api_key",
+       api_username="your_username",
+       test_mode=MOCK_PENDING,
+   )
+
+Every service-name operation accepts a per-call ``test`` override:
+
+.. code-block:: python
+
+   from textverified import MOCK_NO_NUMBERS, NumberType, ReservationCapability
+
+   client.services.verification_inventory(
+       number_type=NumberType.MOBILE,
        service_name="any-real-service-name",
        capability=ReservationCapability.SMS,
+       test=MOCK_NO_NUMBERS,
    )
 
-   # The request used the mock ``test_success`` service. Follow-up calls use
-   # the returned mock resource IDs and work like normal API calls.
-   print(verification.id)
-   print(verification.number)
+The order of precedence is per-call ``test``, per-client ``test_mode``, then
+global ``textverified.test_mode``. Omitting ``test`` inherits that setting;
+passing ``test=None`` explicitly disables testing for that call.
 
-   textverified.mock_api = False
+Supported Operations
+--------------------
 
-You can instead enable mocks for one client without changing the global flag:
+The ``test`` argument is available on all operations that submit a service
+name:
 
-.. code-block:: python
+* ``verifications.create`` and ``verifications.pricing``
+* ``reservations.create`` and ``reservations.pricing``
+* ``services.verification_inventory`` and ``services.rental_inventory``
 
-   client = TextVerified(
-       api_key="your_api_key",
-       api_username="your_username",
-       mock_api=True,
-   )
+The API identifies test responses with the ``X-Phoneblur-Mock: true``
+*response* header. The client does not send that header; it activates a test
+scenario by replacing the request's ``serviceName`` with the selected enum's
+server value.
 
-When enabled, the flag substitutes the API's ``test_success`` service name on
-these POST endpoints:
+Available TestMode Values
+-------------------------
 
-* Verification and rental creation
-* Verification and rental pricing
-* Verification and rental inventory checks
+The enum values below correspond directly to Phoneblur's documented server
+scenarios. They are also available as module-level names, such as
+``textverified.MOCK_SUCCESS``.
 
-All other requests are unchanged. In particular, services, account, and
-follow-up requests use their normal routes. The API identifies mock responses
-with the ``X-Phoneblur-Mock: true`` *response* header; the client deliberately
-does not send that header because it does not activate mocking.
-
-Rental Example
---------------
-
-.. code-block:: python
-
-   import textverified
-   from textverified import (
-       TextVerified,
-       NumberType,
-       RentalDuration,
-       ReservationCapability,
-   )
-
-   client = TextVerified(
-       api_key="your_api_key",
-       api_username="your_username",
-       mock_api=True,
-   )
-
-   sale = client.reservations.create(
-       service_name="any-service",
-       number_type=NumberType.MOBILE,
-       capability=ReservationCapability.SMS,
-       is_renewable=True,
-       duration=RentalDuration.THIRTY_DAY,
-       always_on=True,
-       allow_back_order_reservations=False,
-   )
-   print(sale.id)
-
-
-Scenario Testing
-----------------
-
-For specific server scenarios, leave both mock options disabled and send one
-of the API's documented service names explicitly. The most useful values are:
-
-* ``test_success`` — immediately completed verification or active rental.
-* ``test_delayed_success`` and ``test_pending`` — verification polling flows.
-* ``test_timeout`` and ``test_reactivatable`` — verification terminal states.
-* ``test_renewable_expired`` and ``test_nonrenewable_expired`` — expired rental flows.
-* ``test_backorder`` — rental backorder flow; requires
+* ``MOCK_SUCCESS`` — successful verification or active rental.
+* ``MOCK_DELAYED_SUCCESS`` and ``MOCK_PENDING`` — verification polling flows.
+* ``MOCK_TIMEOUT`` and ``MOCK_REACTIVATABLE`` — verification terminal states.
+* ``MOCK_RENEWABLE_EXPIRED`` and ``MOCK_NONRENEWABLE_EXPIRED`` — expired rentals.
+* ``MOCK_BACKORDER`` — rental backorder; requires
   ``allow_back_order_reservations=True``.
-* ``test_insufficient_balance``, ``test_no_numbers``, and
-  ``test_too_many_unfinished_verifications`` — error handling flows.
+* ``MOCK_INSUFFICIENT_BALANCE`` — API error ``InsufficientBalance``.
+* ``MOCK_NO_NUMBERS`` — API error ``Unavailable``.
+* ``MOCK_TOO_MANY_UNFINISHED_VERIFICATIONS`` — API error
+  ``TooManyUnfinishedVerifications``.
 
-For example, use ``service_name="test_pending"`` to exercise cancellation and
-reporting behavior. Do not enable ``mock_api`` for a custom scenario,
-because mock mode intentionally replaces the supplied name with ``test_success``.
+The verification-only scenarios are ``MOCK_DELAYED_SUCCESS``, ``MOCK_PENDING``,
+``MOCK_TIMEOUT``, ``MOCK_REACTIVATABLE``, and
+``MOCK_TOO_MANY_UNFINISHED_VERIFICATIONS``. The rental-only scenarios are
+``MOCK_RENEWABLE_EXPIRED``, ``MOCK_NONRENEWABLE_EXPIRED``, and
+``MOCK_BACKORDER``. ``MOCK_SUCCESS``, ``MOCK_INSUFFICIENT_BALANCE``, and
+``MOCK_NO_NUMBERS`` work for both kinds of reservation.
+
+Failure Example
+---------------
+
+.. code-block:: python
+
+   from textverified import (
+       MOCK_INSUFFICIENT_BALANCE,
+       ReservationCapability,
+       TextVerified,
+   )
+
+   client = TextVerified(api_key="your_api_key", api_username="your_username")
+
+   # The server returns its normal 400 InsufficientBalance response.
+   client.verifications.create(
+       service_name="any-real-service-name",
+       capability=ReservationCapability.SMS,
+       test=MOCK_INSUFFICIENT_BALANCE,
+   )

--- a/docs/mocking.rst
+++ b/docs/mocking.rst
@@ -1,0 +1,105 @@
+API Mocking
+===========
+
+The client can use Phoneblur's server-backed mock scenarios for integration and
+development testing. Mock responses are deterministic, never deduct balance,
+and never create real resources.
+
+Enable Mocking
+--------------
+
+Mocking is disabled by default. Enable it with the package-level flag or its
+helper function before making requests:
+
+.. code-block:: python
+
+   import textverified
+   from textverified import TextVerified, NumberType, ReservationCapability
+
+   textverified.mock_api = True
+   # Equivalent: textverified.set_mock_api(True)
+
+   client = TextVerified(api_key="your_api_key", api_username="your_username")
+   verification = client.verifications.create(
+       service_name="any-real-service-name",
+       capability=ReservationCapability.SMS,
+   )
+
+   # The request used the mock ``test_success`` service. Follow-up calls use
+   # the returned mock resource IDs and work like normal API calls.
+   print(verification.id)
+   print(verification.number)
+
+   textverified.mock_api = False
+
+You can instead enable mocks for one client without changing the global flag:
+
+.. code-block:: python
+
+   client = TextVerified(
+       api_key="your_api_key",
+       api_username="your_username",
+       mock_api=True,
+   )
+
+When enabled, the flag substitutes the API's ``test_success`` service name on
+these POST endpoints:
+
+* Verification and rental creation
+* Verification and rental pricing
+* Verification and rental inventory checks
+
+All other requests are unchanged. In particular, services, account, and
+follow-up requests use their normal routes. The API identifies mock responses
+with the ``X-Phoneblur-Mock: true`` *response* header; the client deliberately
+does not send that header because it does not activate mocking.
+
+Rental Example
+--------------
+
+.. code-block:: python
+
+   import textverified
+   from textverified import (
+       TextVerified,
+       NumberType,
+       RentalDuration,
+       ReservationCapability,
+   )
+
+   client = TextVerified(
+       api_key="your_api_key",
+       api_username="your_username",
+       mock_api=True,
+   )
+
+   sale = client.reservations.create(
+       service_name="any-service",
+       number_type=NumberType.MOBILE,
+       capability=ReservationCapability.SMS,
+       is_renewable=True,
+       duration=RentalDuration.THIRTY_DAY,
+       always_on=True,
+       allow_back_order_reservations=False,
+   )
+   print(sale.id)
+
+
+Scenario Testing
+----------------
+
+For specific server scenarios, leave both mock options disabled and send one
+of the API's documented service names explicitly. The most useful values are:
+
+* ``test_success`` — immediately completed verification or active rental.
+* ``test_delayed_success`` and ``test_pending`` — verification polling flows.
+* ``test_timeout`` and ``test_reactivatable`` — verification terminal states.
+* ``test_renewable_expired`` and ``test_nonrenewable_expired`` — expired rental flows.
+* ``test_backorder`` — rental backorder flow; requires
+  ``allow_back_order_reservations=True``.
+* ``test_insufficient_balance``, ``test_no_numbers``, and
+  ``test_too_many_unfinished_verifications`` — error handling flows.
+
+For example, use ``service_name="test_pending"`` to exercise cancellation and
+reporting behavior. Do not enable ``mock_api`` for a custom scenario,
+because mock mode intentionally replaces the supplied name with ``test_success``.

--- a/tests/test_api_mocking.py
+++ b/tests/test_api_mocking.py
@@ -5,6 +5,7 @@ import textverified
 
 from .fixtures import mock_http_from_disk, tv
 from textverified import (
+    LIVE,
     MOCK_INSUFFICIENT_BALANCE,
     MOCK_NO_NUMBERS,
     MOCK_PENDING,
@@ -20,13 +21,13 @@ from textverified.verifications_api import VerificationsAPI
 
 @pytest.fixture(autouse=True)
 def reset_test_mode():
-    textverified.test_mode = None
+    textverified.test_mode = LIVE
     yield
-    textverified.test_mode = None
+    textverified.test_mode = LIVE
 
 
-def test_test_mode_is_disabled_by_default():
-    assert textverified.test_mode is None
+def test_test_mode_is_live_by_default():
+    assert textverified.test_mode is LIVE
 
 
 @pytest.mark.parametrize(
@@ -84,13 +85,33 @@ def test_method_test_mode_has_highest_precedence(tv, mock_http_from_disk):
     assert mock_http_from_disk.last_body_params == {"serviceName": "test_insufficient_balance"}
 
 
-def test_test_none_disables_testing_for_one_method(tv, mock_http_from_disk):
+def test_test_none_inherits_testing_for_one_method(tv, mock_http_from_disk):
     textverified.test_mode = MOCK_SUCCESS
     tv.test_mode = MOCK_NO_NUMBERS
 
     tv._perform_action(
         _Action(method="POST", href="/api/pub/v2/verifications"), json={"serviceName": "gmail"}, test=None
     )
+
+    assert mock_http_from_disk.last_body_params == {"serviceName": "test_no_numbers"}
+
+
+def test_live_overrides_an_inherited_test_mode(tv, mock_http_from_disk):
+    textverified.test_mode = MOCK_SUCCESS
+    tv.test_mode = MOCK_NO_NUMBERS
+
+    tv._perform_action(
+        _Action(method="POST", href="/api/pub/v2/verifications"), json={"serviceName": "gmail"}, test=LIVE
+    )
+
+    assert mock_http_from_disk.last_body_params == {"serviceName": "gmail"}
+
+
+def test_client_live_overrides_global_test_mode(tv, mock_http_from_disk):
+    textverified.test_mode = MOCK_SUCCESS
+    tv.test_mode = LIVE
+
+    tv._perform_action(_Action(method="POST", href="/api/pub/v2/verifications"), json={"serviceName": "gmail"})
 
     assert mock_http_from_disk.last_body_params == {"serviceName": "gmail"}
 
@@ -117,6 +138,7 @@ def test_set_test_mode_rejects_non_enum_values():
 
 def test_all_documented_server_test_modes_are_available():
     assert {mode.value for mode in TestMode} == {
+        "live",
         "test_success",
         "test_renewable_expired",
         "test_nonrenewable_expired",

--- a/tests/test_api_mocking.py
+++ b/tests/test_api_mocking.py
@@ -1,0 +1,66 @@
+import textverified
+import pytest
+
+from .fixtures import tv, mock_http_from_disk
+from textverified.action import _Action
+from textverified import TextVerified
+
+
+def test_mock_api_is_disabled_by_default():
+    assert textverified.mock_api is False
+
+
+@pytest.mark.parametrize(
+    "href",
+    [
+        "/api/pub/v2/verifications",
+        "/api/pub/v2/reservations/rental",
+        "/api/pub/v2/pricing/verifications",
+        "/api/pub/v2/pricing/rentals",
+        "/api/pub/v2/inventory/verifications",
+        "/api/pub/v2/inventory/rentals",
+    ],
+)
+def test_mock_api_flag_replaces_service_name_on_supported_request(tv, mock_http_from_disk, href):
+    request_body = {"serviceName": "gmail"}
+    textverified.set_mock_api(True)
+    try:
+        tv._perform_action(_Action(method="POST", href=href), json=request_body)
+    finally:
+        textverified.set_mock_api(False)
+
+    assert mock_http_from_disk.last_body_params == {"serviceName": "test_success"}
+    assert "x-phoneblur-mock" not in mock_http_from_disk.last_header_params
+    assert request_body == {"serviceName": "gmail"}
+
+
+def test_mock_api_flag_does_not_modify_unsupported_request(tv, mock_http_from_disk):
+    textverified.set_mock_api(True)
+    try:
+        tv._perform_action(_Action(method="POST", href="/api/pub/v2/sms/send"), json={"serviceName": "gmail"})
+    finally:
+        textverified.set_mock_api(False)
+
+    assert mock_http_from_disk.last_body_params == {"serviceName": "gmail"}
+
+
+def test_set_mock_api_requires_bool():
+    try:
+        textverified.set_mock_api("true")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("set_mock_api should reject non-boolean values")
+
+
+def test_client_mock_api_flag_replaces_service_name(tv, mock_http_from_disk):
+    tv.mock_api = True
+    tv._perform_action(_Action(method="POST", href="/api/pub/v2/verifications"), json={"serviceName": "gmail"})
+
+    assert mock_http_from_disk.last_body_params == {"serviceName": "test_success"}
+
+
+def test_constructor_accepts_mock_api_flag():
+    client = TextVerified(api_key="test-key", api_username="test-user", mock_api=True)
+
+    assert client.mock_api is True

--- a/tests/test_api_mocking.py
+++ b/tests/test_api_mocking.py
@@ -1,13 +1,32 @@
-import textverified
+import inspect
+
 import pytest
+import textverified
 
-from .fixtures import tv, mock_http_from_disk
+from .fixtures import mock_http_from_disk, tv
+from textverified import (
+    MOCK_INSUFFICIENT_BALANCE,
+    MOCK_NO_NUMBERS,
+    MOCK_PENDING,
+    MOCK_SUCCESS,
+    TestMode,
+    TextVerified,
+)
 from textverified.action import _Action
-from textverified import TextVerified
+from textverified.reservations_api import ReservationsAPI
+from textverified.services_api import ServicesAPI
+from textverified.verifications_api import VerificationsAPI
 
 
-def test_mock_api_is_disabled_by_default():
-    assert textverified.mock_api is False
+@pytest.fixture(autouse=True)
+def reset_test_mode():
+    textverified.test_mode = None
+    yield
+    textverified.test_mode = None
+
+
+def test_test_mode_is_disabled_by_default():
+    assert textverified.test_mode is None
 
 
 @pytest.mark.parametrize(
@@ -21,46 +40,92 @@ def test_mock_api_is_disabled_by_default():
         "/api/pub/v2/inventory/rentals",
     ],
 )
-def test_mock_api_flag_replaces_service_name_on_supported_request(tv, mock_http_from_disk, href):
+@pytest.mark.parametrize(
+    ("mode", "service_name"),
+    [
+        (MOCK_SUCCESS, "test_success"),
+        (MOCK_INSUFFICIENT_BALANCE, "test_insufficient_balance"),
+    ],
+)
+def test_global_test_mode_replaces_service_name(tv, mock_http_from_disk, href, mode, service_name):
+    textverified.test_mode = mode
     request_body = {"serviceName": "gmail"}
-    textverified.set_mock_api(True)
-    try:
-        tv._perform_action(_Action(method="POST", href=href), json=request_body)
-    finally:
-        textverified.set_mock_api(False)
 
-    assert mock_http_from_disk.last_body_params == {"serviceName": "test_success"}
-    assert "x-phoneblur-mock" not in mock_http_from_disk.last_header_params
+    tv._perform_action(_Action(method="POST", href=href), json=request_body)
+
+    assert mock_http_from_disk.last_body_params == {"serviceName": service_name}
     assert request_body == {"serviceName": "gmail"}
 
 
-def test_mock_api_flag_does_not_modify_unsupported_request(tv, mock_http_from_disk):
-    textverified.set_mock_api(True)
-    try:
-        tv._perform_action(_Action(method="POST", href="/api/pub/v2/sms/send"), json={"serviceName": "gmail"})
-    finally:
-        textverified.set_mock_api(False)
+def test_client_test_mode_replaces_service_name(tv, mock_http_from_disk):
+    tv.test_mode = MOCK_NO_NUMBERS
+
+    tv._perform_action(_Action(method="POST", href="/api/pub/v2/verifications"), json={"serviceName": "gmail"})
+
+    assert mock_http_from_disk.last_body_params == {"serviceName": "test_no_numbers"}
+
+
+def test_constructor_accepts_test_mode():
+    client = TextVerified(api_key="test-key", api_username="test-user", test_mode=MOCK_PENDING)
+
+    assert client.test_mode is MOCK_PENDING
+
+
+def test_method_test_mode_has_highest_precedence(tv, mock_http_from_disk):
+    textverified.test_mode = MOCK_SUCCESS
+    tv.test_mode = MOCK_NO_NUMBERS
+
+    tv._perform_action(
+        _Action(method="POST", href="/api/pub/v2/verifications"),
+        json={"serviceName": "gmail"},
+        test=MOCK_INSUFFICIENT_BALANCE,
+    )
+
+    assert mock_http_from_disk.last_body_params == {"serviceName": "test_insufficient_balance"}
+
+
+def test_test_none_disables_testing_for_one_method(tv, mock_http_from_disk):
+    textverified.test_mode = MOCK_SUCCESS
+    tv.test_mode = MOCK_NO_NUMBERS
+
+    tv._perform_action(
+        _Action(method="POST", href="/api/pub/v2/verifications"), json={"serviceName": "gmail"}, test=None
+    )
 
     assert mock_http_from_disk.last_body_params == {"serviceName": "gmail"}
 
 
-def test_set_mock_api_requires_bool():
-    try:
-        textverified.set_mock_api("true")
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("set_mock_api should reject non-boolean values")
+@pytest.mark.parametrize(
+    "method",
+    [
+        VerificationsAPI.create,
+        VerificationsAPI.pricing,
+        ReservationsAPI.create,
+        ReservationsAPI.pricing,
+        ServicesAPI.rental_inventory,
+        ServicesAPI.verification_inventory,
+    ],
+)
+def test_every_service_name_method_accepts_test_mode(method):
+    assert "test" in inspect.signature(method).parameters
 
 
-def test_client_mock_api_flag_replaces_service_name(tv, mock_http_from_disk):
-    tv.mock_api = True
-    tv._perform_action(_Action(method="POST", href="/api/pub/v2/verifications"), json={"serviceName": "gmail"})
-
-    assert mock_http_from_disk.last_body_params == {"serviceName": "test_success"}
+def test_set_test_mode_rejects_non_enum_values():
+    with pytest.raises(ValueError):
+        textverified.set_test_mode("test_success")
 
 
-def test_constructor_accepts_mock_api_flag():
-    client = TextVerified(api_key="test-key", api_username="test-user", mock_api=True)
-
-    assert client.mock_api is True
+def test_all_documented_server_test_modes_are_available():
+    assert {mode.value for mode in TestMode} == {
+        "test_success",
+        "test_renewable_expired",
+        "test_nonrenewable_expired",
+        "test_delayed_success",
+        "test_pending",
+        "test_insufficient_balance",
+        "test_no_numbers",
+        "test_too_many_unfinished_verifications",
+        "test_timeout",
+        "test_reactivatable",
+        "test_backorder",
+    }

--- a/textverified/__init__.py
+++ b/textverified/__init__.py
@@ -15,25 +15,33 @@ Example usage:
 import os
 import sys
 from typing import Optional
+from ._testing import INHERIT_TEST_MODE, TestMode, normalize_test_mode
 
-# Global API mock switch. When enabled, mock-capable requests use the server's
-# documented ``test_success`` service name instead of the supplied service name.
-# It is intentionally disabled by default.
-mock_api = False
+MOCK_SUCCESS = TestMode.MOCK_SUCCESS
+MOCK_RENEWABLE_EXPIRED = TestMode.MOCK_RENEWABLE_EXPIRED
+MOCK_NONRENEWABLE_EXPIRED = TestMode.MOCK_NONRENEWABLE_EXPIRED
+MOCK_DELAYED_SUCCESS = TestMode.MOCK_DELAYED_SUCCESS
+MOCK_PENDING = TestMode.MOCK_PENDING
+MOCK_INSUFFICIENT_BALANCE = TestMode.MOCK_INSUFFICIENT_BALANCE
+MOCK_NO_NUMBERS = TestMode.MOCK_NO_NUMBERS
+MOCK_TOO_MANY_UNFINISHED_VERIFICATIONS = TestMode.MOCK_TOO_MANY_UNFINISHED_VERIFICATIONS
+MOCK_TIMEOUT = TestMode.MOCK_TIMEOUT
+MOCK_REACTIVATABLE = TestMode.MOCK_REACTIVATABLE
+MOCK_BACKORDER = TestMode.MOCK_BACKORDER
+
+# Global server test scenario. ``None`` leaves testing disabled.
+test_mode = None
 
 
-def set_mock_api(enabled: bool) -> None:
-    """Enable or disable server-backed API mocking globally.
+def set_test_mode(mode: Optional[TestMode]) -> None:
+    """Set the global server-backed test scenario.
 
-    When enabled, verification and rental create, pricing, and inventory calls
-    use the API's ``test_success`` mock service. This never affects requests
-    while the flag is disabled.
+    Pass a :class:`TestMode` value to enable a scenario, or ``None`` to turn
+    testing off. Direct assignment to :data:`textverified.test_mode` is also
+    supported.
     """
-    if not isinstance(enabled, bool):
-        raise ValueError("enabled must be a bool.")
-
-    global mock_api
-    mock_api = enabled
+    global test_mode
+    test_mode = normalize_test_mode(mode)
 
 
 # Import the main TextVerified class and API modules
@@ -83,7 +91,7 @@ def configure(
     api_username: str,
     base_url: str = "https://www.textverified.com",
     user_agent: str = "TextVerified-Python-Client/0.1.0",
-    mock_api: bool = False,
+    test_mode=INHERIT_TEST_MODE,
 ) -> None:
     """Configure the static TextVerified instance."""
     global _static_instance
@@ -92,7 +100,7 @@ def configure(
         api_username=api_username,
         base_url=base_url,
         user_agent=user_agent,
-        mock_api=mock_api,
+        test_mode=test_mode,
     )
 
 
@@ -311,8 +319,20 @@ __all__ = [
     "TextVerifiedError",
     # Configuration
     "configure",
-    "mock_api",
-    "set_mock_api",
+    "test_mode",
+    "set_test_mode",
+    "TestMode",
+    "MOCK_SUCCESS",
+    "MOCK_RENEWABLE_EXPIRED",
+    "MOCK_NONRENEWABLE_EXPIRED",
+    "MOCK_DELAYED_SUCCESS",
+    "MOCK_PENDING",
+    "MOCK_INSUFFICIENT_BALANCE",
+    "MOCK_NO_NUMBERS",
+    "MOCK_TOO_MANY_UNFINISHED_VERIFICATIONS",
+    "MOCK_TIMEOUT",
+    "MOCK_REACTIVATABLE",
+    "MOCK_BACKORDER",
     # Static API access
     "account",
     "billing_cycles",

--- a/textverified/__init__.py
+++ b/textverified/__init__.py
@@ -15,8 +15,9 @@ Example usage:
 import os
 import sys
 from typing import Optional
-from ._testing import INHERIT_TEST_MODE, TestMode, normalize_test_mode
+from ._testing import TestMode, normalize_test_mode
 
+LIVE = TestMode.LIVE
 MOCK_SUCCESS = TestMode.MOCK_SUCCESS
 MOCK_RENEWABLE_EXPIRED = TestMode.MOCK_RENEWABLE_EXPIRED
 MOCK_NONRENEWABLE_EXPIRED = TestMode.MOCK_NONRENEWABLE_EXPIRED
@@ -29,15 +30,15 @@ MOCK_TIMEOUT = TestMode.MOCK_TIMEOUT
 MOCK_REACTIVATABLE = TestMode.MOCK_REACTIVATABLE
 MOCK_BACKORDER = TestMode.MOCK_BACKORDER
 
-# Global server test scenario. ``None`` leaves testing disabled.
-test_mode = None
+# Global server test scenario. The default is live operation.
+test_mode = LIVE
 
 
-def set_test_mode(mode: Optional[TestMode]) -> None:
+def set_test_mode(mode: TestMode) -> None:
     """Set the global server-backed test scenario.
 
-    Pass a :class:`TestMode` value to enable a scenario, or ``None`` to turn
-    testing off. Direct assignment to :data:`textverified.test_mode` is also
+    Pass a :class:`TestMode` value. Use :data:`TestMode.LIVE` for ordinary API
+    behavior. Direct assignment to :data:`textverified.test_mode` is also
     supported.
     """
     global test_mode
@@ -91,7 +92,7 @@ def configure(
     api_username: str,
     base_url: str = "https://www.textverified.com",
     user_agent: str = "TextVerified-Python-Client/0.1.0",
-    test_mode=INHERIT_TEST_MODE,
+    test_mode=None,
 ) -> None:
     """Configure the static TextVerified instance."""
     global _static_instance
@@ -322,6 +323,7 @@ __all__ = [
     "test_mode",
     "set_test_mode",
     "TestMode",
+    "LIVE",
     "MOCK_SUCCESS",
     "MOCK_RENEWABLE_EXPIRED",
     "MOCK_NONRENEWABLE_EXPIRED",

--- a/textverified/__init__.py
+++ b/textverified/__init__.py
@@ -16,6 +16,26 @@ import os
 import sys
 from typing import Optional
 
+# Global API mock switch. When enabled, mock-capable requests use the server's
+# documented ``test_success`` service name instead of the supplied service name.
+# It is intentionally disabled by default.
+mock_api = False
+
+
+def set_mock_api(enabled: bool) -> None:
+    """Enable or disable server-backed API mocking globally.
+
+    When enabled, verification and rental create, pricing, and inventory calls
+    use the API's ``test_success`` mock service. This never affects requests
+    while the flag is disabled.
+    """
+    if not isinstance(enabled, bool):
+        raise ValueError("enabled must be a bool.")
+
+    global mock_api
+    mock_api = enabled
+
+
 # Import the main TextVerified class and API modules
 from .textverified import TextVerified, BearerToken
 from .account_api import AccountAPI
@@ -63,11 +83,16 @@ def configure(
     api_username: str,
     base_url: str = "https://www.textverified.com",
     user_agent: str = "TextVerified-Python-Client/0.1.0",
+    mock_api: bool = False,
 ) -> None:
     """Configure the static TextVerified instance."""
     global _static_instance
     _static_instance = TextVerified(
-        api_key=api_key, api_username=api_username, base_url=base_url, user_agent=user_agent
+        api_key=api_key,
+        api_username=api_username,
+        base_url=base_url,
+        user_agent=user_agent,
+        mock_api=mock_api,
     )
 
 
@@ -286,6 +311,8 @@ __all__ = [
     "TextVerifiedError",
     # Configuration
     "configure",
+    "mock_api",
+    "set_mock_api",
     # Static API access
     "account",
     "billing_cycles",

--- a/textverified/_testing.py
+++ b/textverified/_testing.py
@@ -2,13 +2,14 @@ from enum import Enum
 
 
 class TestMode(Enum):
-    """Server-backed Phoneblur test scenarios.
+    """Live operation and server-backed Phoneblur test scenarios.
 
     Each value is the documented ``test_*`` service name understood by the
     Phoneblur API. Use a scenario only with the verification or rental routes
     that support it.
     """
 
+    LIVE = "live"
     MOCK_SUCCESS = "test_success"
     MOCK_RENEWABLE_EXPIRED = "test_renewable_expired"
     MOCK_NONRENEWABLE_EXPIRED = "test_nonrenewable_expired"
@@ -24,21 +25,8 @@ class TestMode(Enum):
     __test__ = False
 
 
-class _InheritedTestMode:
-    def __repr__(self):
-        return "INHERIT_TEST_MODE"
-
-
-INHERIT_TEST_MODE = _InheritedTestMode()
-
-
-def normalize_test_mode(value, allow_inherit=False):
-    """Return a valid test mode, ``None``, or the inheritance sentinel."""
-    if value is INHERIT_TEST_MODE:
-        if allow_inherit:
-            return value
-        raise ValueError("test mode cannot inherit in this context.")
-
+def normalize_test_mode(value):
+    """Return a valid test mode or ``None`` to inherit a parent setting."""
     if value is None or isinstance(value, TestMode):
         return value
 

--- a/textverified/_testing.py
+++ b/textverified/_testing.py
@@ -1,0 +1,45 @@
+from enum import Enum
+
+
+class TestMode(Enum):
+    """Server-backed Phoneblur test scenarios.
+
+    Each value is the documented ``test_*`` service name understood by the
+    Phoneblur API. Use a scenario only with the verification or rental routes
+    that support it.
+    """
+
+    MOCK_SUCCESS = "test_success"
+    MOCK_RENEWABLE_EXPIRED = "test_renewable_expired"
+    MOCK_NONRENEWABLE_EXPIRED = "test_nonrenewable_expired"
+    MOCK_DELAYED_SUCCESS = "test_delayed_success"
+    MOCK_PENDING = "test_pending"
+    MOCK_INSUFFICIENT_BALANCE = "test_insufficient_balance"
+    MOCK_NO_NUMBERS = "test_no_numbers"
+    MOCK_TOO_MANY_UNFINISHED_VERIFICATIONS = "test_too_many_unfinished_verifications"
+    MOCK_TIMEOUT = "test_timeout"
+    MOCK_REACTIVATABLE = "test_reactivatable"
+    MOCK_BACKORDER = "test_backorder"
+
+    __test__ = False
+
+
+class _InheritedTestMode:
+    def __repr__(self):
+        return "INHERIT_TEST_MODE"
+
+
+INHERIT_TEST_MODE = _InheritedTestMode()
+
+
+def normalize_test_mode(value, allow_inherit=False):
+    """Return a valid test mode, ``None``, or the inheritance sentinel."""
+    if value is INHERIT_TEST_MODE:
+        if allow_inherit:
+            return value
+        raise ValueError("test mode cannot inherit in this context.")
+
+    if value is None or isinstance(value, TestMode):
+        return value
+
+    raise ValueError("test mode must be a TestMode value or None.")

--- a/textverified/reservations_api.py
+++ b/textverified/reservations_api.py
@@ -1,7 +1,6 @@
 from .action import _ActionPerformer, _Action
 from typing import List, Union
 from .paginated_list import PaginatedList
-from ._testing import INHERIT_TEST_MODE
 from .data import (
     RenewableRentalCompact,
     RenewableRentalExpanded,
@@ -54,7 +53,7 @@ class ReservationsAPI:
         billing_cycle_id_to_assign_to: str = None,
         service_name: str = None,
         capability: ReservationCapability = None,
-        test=INHERIT_TEST_MODE,
+        test=None,
     ) -> ReservationSaleExpanded:
         """Purchase a new rental. Returns a ReservationSaleExpanded, which contains a list of reservations and backorder reservations.
         You will need to call `.details(obj)` on each reservation to get its full details.
@@ -148,7 +147,7 @@ class ReservationsAPI:
         billing_cycle_id_to_assign_to: str = None,
         is_renewable: bool = None,
         duration: RentalDuration = None,
-        test=INHERIT_TEST_MODE,
+        test=None,
     ) -> PricingSnapshot:
         """Get rental pricing information for a potential rental reservation.
 

--- a/textverified/reservations_api.py
+++ b/textverified/reservations_api.py
@@ -1,6 +1,7 @@
 from .action import _ActionPerformer, _Action
 from typing import List, Union
 from .paginated_list import PaginatedList
+from ._testing import INHERIT_TEST_MODE
 from .data import (
     RenewableRentalCompact,
     RenewableRentalExpanded,
@@ -53,6 +54,7 @@ class ReservationsAPI:
         billing_cycle_id_to_assign_to: str = None,
         service_name: str = None,
         capability: ReservationCapability = None,
+        test=INHERIT_TEST_MODE,
     ) -> ReservationSaleExpanded:
         """Purchase a new rental. Returns a ReservationSaleExpanded, which contains a list of reservations and backorder reservations.
         You will need to call `.details(obj)` on each reservation to get its full details.
@@ -125,7 +127,7 @@ class ReservationsAPI:
             )
 
         action = _Action(method="POST", href="/api/pub/v2/reservations/rental")
-        response = self.client._perform_action(action, json=data.to_api())
+        response = self.client._perform_action(action, json=data.to_api(), test=test)
 
         # Note - response.data is another action to follow to get Sale details
         action = _Action.from_api(response.data)
@@ -146,6 +148,7 @@ class ReservationsAPI:
         billing_cycle_id_to_assign_to: str = None,
         is_renewable: bool = None,
         duration: RentalDuration = None,
+        test=INHERIT_TEST_MODE,
     ) -> PricingSnapshot:
         """Get rental pricing information for a potential rental reservation.
 
@@ -227,7 +230,7 @@ class ReservationsAPI:
             )
 
         action = _Action(method="POST", href="/api/pub/v2/pricing/rentals")
-        response = self.client._perform_action(action, json=data.to_api())
+        response = self.client._perform_action(action, json=data.to_api(), test=test)
 
         return PricingSnapshot.from_api(response.data)
 

--- a/textverified/services_api.py
+++ b/textverified/services_api.py
@@ -1,6 +1,5 @@
 from .action import _ActionPerformer, _Action
 from typing import List
-from ._testing import INHERIT_TEST_MODE
 from .data import (
     AreaCode,
     InventoryQuantity,
@@ -64,7 +63,7 @@ class ServicesAPI:
         number_type: NumberType = None,
         service_name: str = None,
         capability: ReservationCapability = None,
-        test=INHERIT_TEST_MODE,
+        test=None,
     ) -> InventoryQuantity:
         """Get available inventory for a rental configuration.
 
@@ -96,7 +95,7 @@ class ServicesAPI:
         number_type: NumberType = None,
         service_name: str = None,
         capability: ReservationCapability = None,
-        test=INHERIT_TEST_MODE,
+        test=None,
     ) -> InventoryQuantity:
         """Get available inventory for a verification configuration.
 

--- a/textverified/services_api.py
+++ b/textverified/services_api.py
@@ -1,5 +1,6 @@
 from .action import _ActionPerformer, _Action
 from typing import List
+from ._testing import INHERIT_TEST_MODE
 from .data import (
     AreaCode,
     InventoryQuantity,
@@ -63,6 +64,7 @@ class ServicesAPI:
         number_type: NumberType = None,
         service_name: str = None,
         capability: ReservationCapability = None,
+        test=INHERIT_TEST_MODE,
     ) -> InventoryQuantity:
         """Get available inventory for a rental configuration.
 
@@ -83,7 +85,7 @@ class ServicesAPI:
             raise ValueError("All required fields must be provided: duration, number_type, service_name, capability.")
 
         response = self.client._perform_action(
-            _Action(method="POST", href="/api/pub/v2/inventory/rentals"), json=data.to_api()
+            _Action(method="POST", href="/api/pub/v2/inventory/rentals"), json=data.to_api(), test=test
         )
         return InventoryQuantity.from_api(response.data)
 
@@ -94,6 +96,7 @@ class ServicesAPI:
         number_type: NumberType = None,
         service_name: str = None,
         capability: ReservationCapability = None,
+        test=INHERIT_TEST_MODE,
     ) -> InventoryQuantity:
         """Get available inventory for a verification configuration.
 
@@ -113,6 +116,6 @@ class ServicesAPI:
             raise ValueError("All required fields must be provided: number_type, service_name, capability.")
 
         response = self.client._perform_action(
-            _Action(method="POST", href="/api/pub/v2/inventory/verifications"), json=data.to_api()
+            _Action(method="POST", href="/api/pub/v2/inventory/verifications"), json=data.to_api(), test=test
         )
         return InventoryQuantity.from_api(response.data)

--- a/textverified/textverified.py
+++ b/textverified/textverified.py
@@ -13,10 +13,12 @@ from .wake_api import WakeAPI
 from .call_api import CallAPI
 import requests
 import datetime
+import sys
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 import dateutil.parser
 from http.client import responses
+from urllib.parse import urlparse
 
 
 @dataclass(frozen=True)
@@ -39,10 +41,23 @@ class BearerToken:
 class TextVerified(_ActionPerformer):
     """API Context for interacting with the Textverified API."""
 
+    _MOCKABLE_SERVICE_ENDPOINTS = frozenset(
+        (
+            "/api/pub/v2/verifications",
+            "/api/pub/v2/reservations/rental",
+            "/api/pub/v2/pricing/verifications",
+            "/api/pub/v2/pricing/rentals",
+            "/api/pub/v2/inventory/verifications",
+            "/api/pub/v2/inventory/rentals",
+        )
+    )
+    _MOCK_SERVICE_NAME = "test_success"
+
     api_key: str
     api_username: str
     base_url: str = "https://www.textverified.com"
     user_agent: str = "TextVerified-Python-Client/0.1.0"
+    mock_api: bool = False
 
     @property
     def account(self) -> AccountAPI:
@@ -81,6 +96,9 @@ class TextVerified(_ActionPerformer):
         return CallAPI(self)
 
     def __post_init__(self):
+        if not isinstance(self.mock_api, bool):
+            raise ValueError("mock_api must be a bool.")
+
         self.bearer = None
         self.base_url = self.base_url.rstrip("/")
 
@@ -132,6 +150,8 @@ class TextVerified(_ActionPerformer):
         # Check if bearer token is set and valid
         self.refresh_bearer()
 
+        kwargs = self.__apply_mock_service_name(method, href, kwargs)
+
         # Prepare and perform the request
         headers = {"Authorization": f"Bearer {self.bearer.token}", "User-Agent": self.user_agent}
 
@@ -142,6 +162,30 @@ class TextVerified(_ActionPerformer):
 
         TextVerified.__raise_for_status(method, href, response)
         return _ActionResponse(data=response.json() if response.text else {}, headers=response.headers)
+
+    def __apply_mock_service_name(self, method: str, href: str, request_kwargs: Dict) -> Dict:
+        """Apply the global server-backed mock setting to supported requests.
+
+        The Phoneblur API enables mocks by receiving a documented ``test_*``
+        service name; ``X-Phoneblur-Mock`` is a response header, not a request
+        header. Copy the request data to avoid mutating a caller's payload.
+        """
+        package = sys.modules.get(__package__)
+        if not self.mock_api and not (package and getattr(package, "mock_api", False)):
+            return request_kwargs
+
+        if method.upper() != "POST" or urlparse(href).path not in self._MOCKABLE_SERVICE_ENDPOINTS:
+            return request_kwargs
+
+        request_json = request_kwargs.get("json")
+        if not isinstance(request_json, dict) or "serviceName" not in request_json:
+            return request_kwargs
+
+        request_kwargs = request_kwargs.copy()
+        request_json = request_json.copy()
+        request_json["serviceName"] = self._MOCK_SERVICE_NAME
+        request_kwargs["json"] = request_json
+        return request_kwargs
 
     def __perform_action_external(self, method: str, href: str, **kwargs) -> _ActionResponse:
         """External action performance without authorization"""

--- a/textverified/textverified.py
+++ b/textverified/textverified.py
@@ -11,7 +11,7 @@ from .sms_api import SMSApi
 from .verifications_api import VerificationsAPI
 from .wake_api import WakeAPI
 from .call_api import CallAPI
-from ._testing import INHERIT_TEST_MODE, TestMode, normalize_test_mode
+from ._testing import TestMode, normalize_test_mode
 import requests
 import datetime
 import sys
@@ -56,7 +56,7 @@ class TextVerified(_ActionPerformer):
     api_username: str
     base_url: str = "https://www.textverified.com"
     user_agent: str = "TextVerified-Python-Client/0.1.0"
-    test_mode: Optional[TestMode] = INHERIT_TEST_MODE
+    test_mode: Optional[TestMode] = None
 
     @property
     def account(self) -> AccountAPI:
@@ -95,7 +95,7 @@ class TextVerified(_ActionPerformer):
         return CallAPI(self)
 
     def __post_init__(self):
-        self.test_mode = normalize_test_mode(self.test_mode, allow_inherit=True)
+        self.test_mode = normalize_test_mode(self.test_mode)
 
         self.bearer = None
         self.base_url = self.base_url.rstrip("/")
@@ -135,7 +135,7 @@ class TextVerified(_ActionPerformer):
         :param action: The action to perform
         :return: Dictionary containing the API response
         """
-        test = normalize_test_mode(kwargs.pop("test", INHERIT_TEST_MODE), allow_inherit=True)
+        test = normalize_test_mode(kwargs.pop("test", None))
         if "://" in action.href and not action.href.startswith(self.base_url):
             return self.__perform_action_external(action.method, action.href, **kwargs)
         else:
@@ -144,7 +144,7 @@ class TextVerified(_ActionPerformer):
                 href = f"{self.base_url}{action.href}"
             return self.__perform_action_internal(action.method, href, test=test, **kwargs)
 
-    def __perform_action_internal(self, method: str, href: str, test=INHERIT_TEST_MODE, **kwargs) -> _ActionResponse:
+    def __perform_action_internal(self, method: str, href: str, test=None, **kwargs) -> _ActionResponse:
         """Internal action performance with authorization"""
         # Check if bearer token is set and valid
         self.refresh_bearer()
@@ -170,7 +170,7 @@ class TextVerified(_ActionPerformer):
         header. Copy the request data to avoid mutating a caller's payload.
         """
         mode = self.__effective_test_mode(test)
-        if mode is None:
+        if mode is TestMode.LIVE:
             return request_kwargs
 
         if method.upper() != "POST" or urlparse(href).path not in self._MOCKABLE_SERVICE_ENDPOINTS:
@@ -187,14 +187,15 @@ class TextVerified(_ActionPerformer):
         return request_kwargs
 
     def __effective_test_mode(self, test):
-        if test is not INHERIT_TEST_MODE:
+        if test is not None:
             return test
 
-        if self.test_mode is not INHERIT_TEST_MODE:
+        if self.test_mode is not None:
             return self.test_mode
 
         package = sys.modules.get(__package__)
-        return normalize_test_mode(getattr(package, "test_mode", None)) if package else None
+        mode = normalize_test_mode(getattr(package, "test_mode", TestMode.LIVE)) if package else TestMode.LIVE
+        return mode or TestMode.LIVE
 
     def __perform_action_external(self, method: str, href: str, **kwargs) -> _ActionResponse:
         """External action performance without authorization"""

--- a/textverified/textverified.py
+++ b/textverified/textverified.py
@@ -11,6 +11,7 @@ from .sms_api import SMSApi
 from .verifications_api import VerificationsAPI
 from .wake_api import WakeAPI
 from .call_api import CallAPI
+from ._testing import INHERIT_TEST_MODE, TestMode, normalize_test_mode
 import requests
 import datetime
 import sys
@@ -51,13 +52,11 @@ class TextVerified(_ActionPerformer):
             "/api/pub/v2/inventory/rentals",
         )
     )
-    _MOCK_SERVICE_NAME = "test_success"
-
     api_key: str
     api_username: str
     base_url: str = "https://www.textverified.com"
     user_agent: str = "TextVerified-Python-Client/0.1.0"
-    mock_api: bool = False
+    test_mode: Optional[TestMode] = INHERIT_TEST_MODE
 
     @property
     def account(self) -> AccountAPI:
@@ -96,8 +95,7 @@ class TextVerified(_ActionPerformer):
         return CallAPI(self)
 
     def __post_init__(self):
-        if not isinstance(self.mock_api, bool):
-            raise ValueError("mock_api must be a bool.")
+        self.test_mode = normalize_test_mode(self.test_mode, allow_inherit=True)
 
         self.bearer = None
         self.base_url = self.base_url.rstrip("/")
@@ -137,20 +135,21 @@ class TextVerified(_ActionPerformer):
         :param action: The action to perform
         :return: Dictionary containing the API response
         """
+        test = normalize_test_mode(kwargs.pop("test", INHERIT_TEST_MODE), allow_inherit=True)
         if "://" in action.href and not action.href.startswith(self.base_url):
             return self.__perform_action_external(action.method, action.href, **kwargs)
         else:
             href = action.href
             if not action.href.startswith(self.base_url):
                 href = f"{self.base_url}{action.href}"
-            return self.__perform_action_internal(action.method, href, **kwargs)
+            return self.__perform_action_internal(action.method, href, test=test, **kwargs)
 
-    def __perform_action_internal(self, method: str, href: str, **kwargs) -> _ActionResponse:
+    def __perform_action_internal(self, method: str, href: str, test=INHERIT_TEST_MODE, **kwargs) -> _ActionResponse:
         """Internal action performance with authorization"""
         # Check if bearer token is set and valid
         self.refresh_bearer()
 
-        kwargs = self.__apply_mock_service_name(method, href, kwargs)
+        kwargs = self.__apply_test_service_name(method, href, test, kwargs)
 
         # Prepare and perform the request
         headers = {"Authorization": f"Bearer {self.bearer.token}", "User-Agent": self.user_agent}
@@ -163,15 +162,15 @@ class TextVerified(_ActionPerformer):
         TextVerified.__raise_for_status(method, href, response)
         return _ActionResponse(data=response.json() if response.text else {}, headers=response.headers)
 
-    def __apply_mock_service_name(self, method: str, href: str, request_kwargs: Dict) -> Dict:
-        """Apply the global server-backed mock setting to supported requests.
+    def __apply_test_service_name(self, method: str, href: str, test, request_kwargs: Dict) -> Dict:
+        """Apply the effective server-backed test scenario to supported requests.
 
-        The Phoneblur API enables mocks by receiving a documented ``test_*``
-        service name; ``X-Phoneblur-Mock`` is a response header, not a request
+        The API enables test scenarios by receiving a documented ``test_*``
+        service name. ``X-Phoneblur-Mock`` is a response header, not a request
         header. Copy the request data to avoid mutating a caller's payload.
         """
-        package = sys.modules.get(__package__)
-        if not self.mock_api and not (package and getattr(package, "mock_api", False)):
+        mode = self.__effective_test_mode(test)
+        if mode is None:
             return request_kwargs
 
         if method.upper() != "POST" or urlparse(href).path not in self._MOCKABLE_SERVICE_ENDPOINTS:
@@ -183,9 +182,19 @@ class TextVerified(_ActionPerformer):
 
         request_kwargs = request_kwargs.copy()
         request_json = request_json.copy()
-        request_json["serviceName"] = self._MOCK_SERVICE_NAME
+        request_json["serviceName"] = mode.value
         request_kwargs["json"] = request_json
         return request_kwargs
+
+    def __effective_test_mode(self, test):
+        if test is not INHERIT_TEST_MODE:
+            return test
+
+        if self.test_mode is not INHERIT_TEST_MODE:
+            return self.test_mode
+
+        package = sys.modules.get(__package__)
+        return normalize_test_mode(getattr(package, "test_mode", None)) if package else None
 
     def __perform_action_external(self, method: str, href: str, **kwargs) -> _ActionResponse:
         """External action performance without authorization"""

--- a/textverified/verifications_api.py
+++ b/textverified/verifications_api.py
@@ -1,6 +1,7 @@
 from .action import _ActionPerformer, _Action
 from typing import List, Union
 from .paginated_list import PaginatedList
+from ._testing import INHERIT_TEST_MODE
 from .data import (
     VerificationPriceCheckRequest,
     NewVerificationRequest,
@@ -28,6 +29,7 @@ class VerificationsAPI:
         capability: ReservationCapability = None,
         service_not_listed_name: str = None,
         max_price: float = None,
+        test=INHERIT_TEST_MODE,
     ) -> VerificationExpanded:
         """Create a new verification for phone number verification purposes.
 
@@ -86,7 +88,7 @@ class VerificationsAPI:
             )
 
         action = _Action(method="POST", href="/api/pub/v2/verifications")
-        response = self.client._perform_action(action, json=data.to_api())
+        response = self.client._perform_action(action, json=data.to_api(), test=test)
 
         # Note - response.data is another action to follow to get Verification details
 
@@ -104,6 +106,7 @@ class VerificationsAPI:
         carrier: bool = None,
         number_type: NumberType = None,
         capability: ReservationCapability = None,
+        test=INHERIT_TEST_MODE,
     ) -> PricingSnapshot:
         """Get pricing information for a verification before creating it.
 
@@ -167,7 +170,7 @@ class VerificationsAPI:
             )
 
         action = _Action(method="POST", href="/api/pub/v2/pricing/verifications")
-        response = self.client._perform_action(action, json=data.to_api())
+        response = self.client._perform_action(action, json=data.to_api(), test=test)
 
         return PricingSnapshot.from_api(response.data)
 

--- a/textverified/verifications_api.py
+++ b/textverified/verifications_api.py
@@ -1,7 +1,6 @@
 from .action import _ActionPerformer, _Action
 from typing import List, Union
 from .paginated_list import PaginatedList
-from ._testing import INHERIT_TEST_MODE
 from .data import (
     VerificationPriceCheckRequest,
     NewVerificationRequest,
@@ -29,7 +28,7 @@ class VerificationsAPI:
         capability: ReservationCapability = None,
         service_not_listed_name: str = None,
         max_price: float = None,
-        test=INHERIT_TEST_MODE,
+        test=None,
     ) -> VerificationExpanded:
         """Create a new verification for phone number verification purposes.
 
@@ -106,7 +105,7 @@ class VerificationsAPI:
         carrier: bool = None,
         number_type: NumberType = None,
         capability: ReservationCapability = None,
-        test=INHERIT_TEST_MODE,
+        test=None,
     ) -> PricingSnapshot:
         """Get pricing information for a verification before creating it.
 


### PR DESCRIPTION
## Summary
- Add global textverified.mock_api flag and per-client mock_api=True support
- Use Phoneblur test_* service scenarios without sending a mock request header
- Add Sphinx documentation and test coverage

## Validation
- conda run -n tv-py37 python -m pytest